### PR TITLE
fix: resolve SentimentType enum case mismatch error

### DIFF
--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -4,21 +4,21 @@ from typing import List, Dict
 from enum import Enum
 
 class SentimentType(str, Enum):
-    POSITIVE = "POSITIVE"
-    NEGATIVE = "NEGATIVE"
-    OTHER = "OTHER"
+    POSITIVE = "positive"
+    NEGATIVE = "negative"
+    OTHER = "other"
 
 class DetailSentimentType(str, Enum):
     # positive
-    JOY = "JOY"
-    LOVE = "LOVE"
-    GRATITUDE = "GRATITUDE"
+    JOY = "joy"
+    LOVE = "love"
+    GRATITUDE = "gratitude"
     # negative
-    ANGER = "ANGER"
-    SADNESS = "SADNESS"
-    FEAR = "FEAR"
+    ANGER = "anger"
+    SADNESS = "sadness"
+    FEAR = "fear"
     # other
-    NEUTRAL = "NEUTRAL"
+    NEUTRAL = "neutral"
 
 class CommentSentimentDetail(BaseModel):
     apiCommentId: str

--- a/src/pipelines/sentiment.py
+++ b/src/pipelines/sentiment.py
@@ -354,7 +354,7 @@ async def analyze_sentiment_async(
             apiCommentId=cid,
             content=text,
             sentimentType=SentimentType(sentiment_type),
-            detailSentimentTypes=[DetailSentimentType(e.upper()) for e in detail_emotions]  # 🔄 리스트로 변환
+            detailSentimentTypes=[DetailSentimentType(e) for e in detail_emotions]  # 🔄 리스트로 변환
         )
         sentiment_comments.append(comment_detail)
 


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->

---

### 📌 요약
- SentimentType enum 대소문자 불일치로 인한 ValueError 해결
- 감정 분석 결과가 기본값(33/33/34)으로 고정되던 문제 수정

### ✅ 작업 내용
- `schemas.py`: `SentimentType` enum 값을 대문자 → 소문자로 변경
  - `POSITIVE = "POSITIVE"` → `POSITIVE = "positive"`
  - `NEGATIVE = "NEGATIVE"` → `NEGATIVE = "negative"`
  - `OTHER = "OTHER"` → `OTHER = "other"`
- `sentiment.py` (362번째 줄): `DetailSentimentType` 생성 시 `.upper()` 제거
  - `DetailSentimentType(e.upper())` → `DetailSentimentType(e)`
- `detail_to_sentiment_map` 딕셔너리의 값들이 소문자로 되어 있어서 enum과 일치시킴

### 💭 리뷰 포인트
- `sentiment.py`의 `detail_to_sentiment_map`에서 소문자 값을 사용하고 있어서, enum 정의를 소문자로 통일함
- 이제 감정 분석이 정상적으로 작동하며 실제 분석 결과 비율이 출력됨

### 📚 참고 자료, 할 말
- 에러 로그: `ValueError: 'negative' is not a valid SentimentType`
- Phase 0 번역 최적화 이후 발견된 버그
- 기존에는 에러가 발생해도 기본값(33/33/34)으로 처리되어 문제를 발견하기 어려웠음