### PR TITLE
feat: 다국어 키워드 추출 및 명사 필터링 기능 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,14 +6,17 @@ colorama==0.4.6
 distro==1.9.0
 filelock==3.20.0
 fsspec==2025.9.0
+fugashi==1.4.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
 huggingface-hub==0.35.3
 idna==3.11
+jieba==0.42.1
 Jinja2==3.1.6
 jiter==0.11.1
 joblib==1.5.2
+kiwipiepy==0.21.1
 langdetect==1.0.9
 MarkupSafe==3.0.3
 mpmath==1.3.0
@@ -36,6 +39,8 @@ scipy==1.16.2
 setuptools==80.9.0
 six==1.17.0
 sniffio==1.3.1
+spacy==3.8.7
+stanza==1.10.1
 sympy==1.13.1
 threadpoolctl==3.6.0
 tokenizers==0.22.1
@@ -45,5 +50,6 @@ transformers==4.57.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.2
+unidic-lite==1.0.8
 urllib3==2.5.0
 wheel==0.45.1

--- a/src/pipelines/keywords.py
+++ b/src/pipelines/keywords.py
@@ -1,14 +1,15 @@
 # src/pipelines/keywords.py
 """
-[기능3] TF-IDF 기반 키워드 분석 (불용어 정제 + 부분중복 제거 버전)
-- NLTK 없이 작동
-- 한국어/영어 공통 불용어 필터링
-- 1~2 gram 사용 + 결과에서 부분문자열(긴 구절) 중복 제거
+[기능3] TF-IDF 기반 키워드 분석 (다국어 명사 추출 버전)
+- langdetect로 언어 감지 후 언어별 토크나이저 분기
+- 한국어: kiwipiepy, 영어: spaCy, 일본어: fugashi, 중국어: jieba
+- 기타 70개+ 언어: Stanza
+- 불용어 필터링 + 1~2 gram + 부분중복 제거
 """
 import os
 import sys
 import re
-from typing import List
+from typing import List, Set
 
 # ============================================================
 # Windows 한글 깨짐 방지 (최상단 배치)
@@ -33,12 +34,15 @@ if sys.platform == 'win32':
     # 3. Windows 콘솔 코드 페이지를 UTF-8로 설정
     try:
         import subprocess
-        subprocess.run(['chcp', '65001'], shell=True, 
-                      capture_output=True, check=False)
+        subprocess.run(['chcp', '65001'], shell=True, capture_output=True, check=False)
     except Exception:
         pass
 
 from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
+from langdetect import detect, LangDetectException
+
+# 언어별 라이브러리
+from kiwipiepy import Kiwi
 
 # ============================================================
 # API 키 및 유틸리티 불러오기
@@ -50,94 +54,370 @@ except ImportError:
     from ..config import YOUTUBE_API_KEY, VIDEO_KEY
     from ..utils.youtube import fetch_youtube_comments
 
-# -----------------------------
-# 1) 불용어 (영어 + 한국어)
-# -----------------------------
+# ============================================================
+# 1) 언어별 불용어
+# ============================================================
 KO_STOPWORDS = {
-    # 요청 예시
-    "진짜", "정말", "다시", "너무",
     # 일반 잡음/구어체
+    "진짜", "정말", "다시", "너무", "최고",
     "그냥", "근데", "그리고", "하지만", "또", "또한", "이거", "저거", "그거",
     "이건", "저건", "그건", "거의", "그렇죠", "그렇다", "거든요", "뭔가",
     "에서", "으로", "이나", "하고", "같아요", "같은", "거에요", "거예요",
-    "근데요", "근데요", "아니", "아니요", "막", "또요", "좀", "그럼", "그래도",
-    "이게", "제발"
+    "근데요", "아니", "아니요", "막", "또요", "좀", "그럼", "그래도",
+    "이게", "제발",
+    # 감탄/칭찬 표현
+    "대박", "짱", "굿", "쩔어", "미쳤", "레전드", "갓", "킹",
+    "천재", "존잘", "존예", "개꿀", "실화", "인정", "ㅋㅋ", "ㅎㅎ",
+    "와", "우와", "헐", "오", "아",
+    # 유튜브 관련 명사
+    "영상", "채널", "구독", "알림", "시청", "댓글", "추천", "조회",
+    "좋아요", "설정",
+    # 일반적 칭찬/감정 명사
+    "감사", "응원", "사랑", "최애", "공감",
+    # 추상적/지시적 일반 명사
+    "것", "수", "거", "때", "말", "게", "점", "번", "분", "중",
+    "정도", "이유", "생각", "느낌", "기분", "마음", "부분", "경우",
+    "사람", "모습", "얘기", "이야기", "내용", "정보", "도움",
 }
-# 영어 기본 불용어 (scikit-learn 내장)
-EN_STOPWORDS = set(ENGLISH_STOP_WORDS)
 
-# 하나로 합치기
-COMMON_STOPWORDS = KO_STOPWORDS.union(EN_STOPWORDS)
+JA_STOPWORDS = {
+    "これ", "それ", "あれ", "この", "その", "あの",
+    "ここ", "そこ", "あそこ", "こちら", "どこ", "だれ",
+    "なに", "なん", "何", "私", "僕", "俺", "あなた",
+    "こと", "もの", "ため", "よう", "ところ", "とき",
+    "動画", "チャンネル", "登録", "視聴", "コメント",
+    "最高", "すごい", "やばい", "神", "草", "笑",
+}
 
-# -----------------------------
-# 2) 간단 토크나이저
-# -----------------------------
-_word_pat = re.compile(r"[A-Za-z]+|[가-힣]+")
+ZH_STOPWORDS = {
+    "的", "了", "是", "我", "你", "他", "她", "它",
+    "这", "那", "哪", "什么", "怎么", "为什么",
+    "很", "太", "真", "好", "吗", "呢", "啊", "吧",
+    "视频", "频道", "订阅", "观看", "评论", "点赞",
+    "最", "更", "非常", "特别", "一个", "这个", "那个",
+}
 
-def _simple_tokenizer(text: str) -> List[str]:
-    """
-    - 영문/한글 토큰만 추출
-    - 영어는 소문자화
-    - 길이 1 토큰/불용어 제거
-    """
-    tokens = _word_pat.findall(text or "")
+DE_STOPWORDS = {
+    # 일반 불용어
+    "danke", "bitte", "mal", "auch", "noch", "schon", "sehr", "ganz",
+    "ja", "nein", "nicht", "aber", "oder", "und", "mit", "für", "von",
+    "das", "der", "die", "ein", "eine", "ist", "sind", "war", "haben",
+    "wird", "kann", "muss", "soll", "wir", "ihr", "sie", "ich", "du",
+    # 유튜브 관련
+    "video", "kanal", "abo", "abonnieren", "like", "kommentar",
+    # 감탄/칭찬 표현
+    "toll", "super", "geil", "krass", "nice", "cool", "mega", "hammer",
+}
+
+FR_STOPWORDS = {
+    # 일반 불용어
+    "merci", "bien", "très", "aussi", "encore", "mais", "ou", "et", "avec",
+    "pour", "dans", "sur", "par", "pas", "plus", "moins", "tout", "tous",
+    "le", "la", "les", "un", "une", "des", "ce", "cette", "ces",
+    "je", "tu", "il", "elle", "nous", "vous", "ils", "elles",
+    "est", "sont", "être", "avoir", "fait", "faire",
+    # 유튜브 관련
+    "vidéo", "chaîne", "abonner", "commentaire",
+    # 감탄/칭찬 표현
+    "génial", "super", "magnifique", "incroyable", "top", "bravo",
+}
+
+ES_STOPWORDS = {
+    # 일반 불용어
+    "gracias", "bien", "muy", "también", "pero", "más", "menos",
+    "el", "la", "los", "las", "un", "una", "unos", "unas",
+    "de", "del", "en", "con", "por", "para", "sin", "sobre",
+    "yo", "tú", "él", "ella", "nosotros", "vosotros", "ellos", "ellas",
+    "es", "son", "está", "están", "ser", "estar", "haber", "tener",
+    "que", "qué", "como", "cómo", "cuando", "cuándo", "donde", "dónde",
+    # 유튜브 관련
+    "video", "canal", "suscribir", "comentario",
+    # 감탄/칭찬 표현
+    "genial", "increíble", "fantástico", "excelente", "bueno", "buena",
+}
+
+RU_STOPWORDS = {
+    # 일반 불용어
+    "спасибо", "очень", "тоже", "также", "но", "и", "или", "а",
+    "в", "на", "с", "по", "за", "из", "от", "до", "для", "без",
+    "я", "ты", "он", "она", "мы", "вы", "они", "это", "эта", "этот",
+    "что", "как", "где", "когда", "почему", "кто",
+    "есть", "быть", "было", "будет", "был", "была",
+    # 유튜브 관련
+    "видео", "канал", "подписка", "комментарий",
+    # 감탄/칭찬 표현
+    "круто", "класс", "супер", "отлично", "здорово", "молодец",
+}
+
+# 범용 불용어 (유튜브 관련, 다국어 공통 인터넷 표현)
+UNIVERSAL_STOPWORDS = {
+    # 유튜브/인터넷 관련
+    "video", "channel", "subscribe", "like", "comment", "watch",
+    "youtube", "http", "https", "www", "com", "org", "net",
+    # 인터넷 감탄사/이모티콘
+    "lol", "omg", "wow", "haha", "hehe", "hihi", "xd", "xdd",
+    "nice", "cool", "good", "great", "awesome", "amazing",
+    # 숫자/기호
+    "00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+}
+
+EN_STOPWORDS = set(ENGLISH_STOP_WORDS) | UNIVERSAL_STOPWORDS
+
+# 전체 불용어 합치기
+ALL_STOPWORDS = (
+    KO_STOPWORDS | EN_STOPWORDS | JA_STOPWORDS | ZH_STOPWORDS |
+    DE_STOPWORDS | FR_STOPWORDS | ES_STOPWORDS | RU_STOPWORDS |
+    UNIVERSAL_STOPWORDS
+)
+
+# ============================================================
+# 2) 언어별 분석기 인스턴스 (지연 로딩)
+# ============================================================
+_kiwi = None       # 한국어
+_spacy_en = None   # 영어
+_fugashi = None    # 일본어
+_stanza_pipelines = {}  # 기타 언어용 Stanza (언어별 캐싱)
+
+def _get_kiwi():
+    """한국어: Kiwi 인스턴스 지연 로딩"""
+    global _kiwi
+    if _kiwi is None:
+        print("[INFO] Kiwi 형태소 분석기 로딩 중...")
+        _kiwi = Kiwi()
+        print("[SUCCESS] Kiwi 로딩 완료!")
+    return _kiwi
+
+def _get_spacy_en():
+    """영어: spaCy 인스턴스 지연 로딩"""
+    global _spacy_en
+    if _spacy_en is None:
+        print("[INFO] spaCy 영어 모델 로딩 중...")
+        import spacy
+        _spacy_en = spacy.load("en_core_web_sm")
+        print("[SUCCESS] spaCy 로딩 완료!")
+    return _spacy_en
+
+def _get_fugashi():
+    """일본어: fugashi 인스턴스 지연 로딩"""
+    global _fugashi
+    if _fugashi is None:
+        print("[INFO] Fugashi 형태소 분석기 로딩 중...")
+        import fugashi
+        _fugashi = fugashi.Tagger()
+        print("[SUCCESS] Fugashi 로딩 완료!")
+    return _fugashi
+
+def _get_stanza_pipeline(lang: str):
+    """기타 언어: Stanza 파이프라인 지연 로딩 (언어별 캐싱)"""
+    global _stanza_pipelines
+    
+    if lang not in _stanza_pipelines:
+        print(f"[INFO] Stanza '{lang}' 모델 로딩 중...")
+        import stanza
+        
+        try:
+            # 모델 다운로드 (이미 있으면 스킵)
+            stanza.download(lang, verbose=False)
+            _stanza_pipelines[lang] = stanza.Pipeline(lang, processors='tokenize,pos', verbose=False)
+            print(f"[SUCCESS] Stanza '{lang}' 로딩 완료!")
+        except Exception as e:
+            print(f"[WARNING] Stanza '{lang}' 로딩 실패: {e}")
+            _stanza_pipelines[lang] = None
+    
+    return _stanza_pipelines.get(lang)
+
+# ============================================================
+# 3) Stanza 지원 언어 목록
+# ============================================================
+# langdetect 코드 → Stanza 코드 매핑 (다른 경우만)
+LANGDETECT_TO_STANZA = {
+    "zh-cn": "zh-hans",
+    "zh-tw": "zh-hant",
+}
+
+# Stanza가 지원하는 주요 언어들 (70개+)
+STANZA_SUPPORTED = {
+    "af", "ar", "be", "bg", "ca", "cs", "da", "de", "el", "es", "et", "eu",
+    "fa", "fi", "fr", "ga", "gl", "he", "hi", "hr", "hu", "hy", "id", "it",
+    "la", "lt", "lv", "mk", "mt", "nl", "no", "pl", "pt", "ro", "ru", "sk",
+    "sl", "sr", "sv", "ta", "te", "th", "tr", "uk", "ur", "vi",
+    "zh-hans", "zh-hant",
+}
+
+# ============================================================
+# 4) 언어별 명사 추출 함수
+# ============================================================
+def _korean_nouns(text: str) -> List[str]:
+    """한국어 명사 추출 (kiwipiepy)"""
+    kiwi = _get_kiwi()
+    result = kiwi.tokenize(text or "")
+    
     out = []
-    for t in tokens:
-        if re.fullmatch(r"[A-Za-z]+", t):
-            tt = t.lower()
-        else:
-            tt = t  # 한글은 소문자 개념 없음
-
-        if len(tt) < 2:
-            continue
-        if tt in COMMON_STOPWORDS:
-            continue
-        out.append(tt)
+    for token in result:
+        word = token.form
+        pos = token.tag
+        
+        # NNG(일반명사), NNP(고유명사)
+        if pos in ('NNG', 'NNP'):
+            if len(word) >= 2 and word not in KO_STOPWORDS:
+                out.append(word)
+        # SL(외국어) - 한국어 텍스트 내 영어 단어
+        elif pos == 'SL':
+            word_lower = word.lower()
+            if len(word_lower) >= 2 and word_lower not in EN_STOPWORDS:
+                out.append(word_lower)
+    
     return out
 
-# -----------------------------
-# 3) 부분문자열(중복) 제거
-# -----------------------------
+def _english_nouns(text: str) -> List[str]:
+    """영어 명사 추출 (spaCy)"""
+    nlp = _get_spacy_en()
+    doc = nlp(text or "")
+    
+    out = []
+    for token in doc:
+        # NOUN(일반명사), PROPN(고유명사)
+        if token.pos_ in ('NOUN', 'PROPN'):
+            word = token.text.lower()
+            if len(word) >= 2 and word not in EN_STOPWORDS:
+                out.append(word)
+    
+    return out
+
+def _japanese_nouns(text: str) -> List[str]:
+    """일본어 명사 추출 (fugashi)"""
+    tagger = _get_fugashi()
+    
+    out = []
+    for word in tagger(text or ""):
+        # feature: 품사 정보 (명사 = 名詞)
+        if word.feature.pos1 == '名詞':
+            surface = word.surface
+            if len(surface) >= 2 and surface not in JA_STOPWORDS:
+                out.append(surface)
+    
+    return out
+
+def _chinese_nouns(text: str) -> List[str]:
+    """중국어 명사 추출 (jieba)"""
+    import jieba
+    import jieba.posseg as pseg
+    
+    out = []
+    words = pseg.cut(text or "")
+    for word, flag in words:
+        # n: 명사, nr: 인명, ns: 지명, nt: 기관명, nz: 기타 고유명사
+        if flag.startswith('n'):
+            if len(word) >= 2 and word not in ZH_STOPWORDS:
+                out.append(word)
+    
+    return out
+
+def _stanza_nouns(text: str, lang: str) -> List[str]:
+    """기타 언어 명사 추출 (Stanza)"""
+    # langdetect → Stanza 언어 코드 변환
+    stanza_lang = LANGDETECT_TO_STANZA.get(lang, lang)
+    
+    pipeline = _get_stanza_pipeline(stanza_lang)
+    if pipeline is None:
+        return _fallback_tokenizer(text)
+    
+    out = []
+    try:
+        doc = pipeline(text or "")
+        for sentence in doc.sentences:
+            for word in sentence.words:
+                # NOUN(일반명사), PROPN(고유명사)
+                if word.upos in ('NOUN', 'PROPN'):
+                    w = word.text.lower() if word.text.isascii() else word.text
+                    if len(w) >= 2 and w not in ALL_STOPWORDS:
+                        out.append(w)
+    except Exception as e:
+        print(f"[WARNING] Stanza 처리 실패: {e}")
+        return _fallback_tokenizer(text)
+    
+    return out
+
+def _fallback_tokenizer(text: str) -> List[str]:
+    """최후의 fallback (정규식 기반)"""
+    pattern = re.compile(r'[\w]+', re.UNICODE)
+    tokens = pattern.findall(text or "")
+    
+    out = []
+    for t in tokens:
+        if t.isdigit():
+            continue
+        if len(t) >= 2:
+            w = t.lower() if t.isascii() else t
+            if w not in ALL_STOPWORDS:
+                out.append(w)
+    
+    return out
+
+# ============================================================
+# 5) 통합 토크나이저 (언어 감지 → 분기)
+# ============================================================
+def _multilingual_noun_tokenizer(text: str) -> List[str]:
+    """
+    다국어 명사 추출 토크나이저
+    - langdetect로 언어 감지
+    - 언어별 적절한 토크나이저로 분기
+    - 지원되지 않는 언어는 Stanza 또는 fallback 사용
+    """
+    if not text or len(text.strip()) < 3:
+        return []
+    
+    try:
+        lang = detect(text)
+    except LangDetectException:
+        lang = "unknown"
+    
+    # 언어별 분기 (최적화된 라이브러리 우선)
+    if lang == "ko":
+        return _korean_nouns(text)
+    elif lang == "en":
+        return _english_nouns(text)
+    elif lang == "ja":
+        return _japanese_nouns(text)
+    elif lang in ("zh-cn", "zh-tw"):
+        return _chinese_nouns(text)
+    else:
+        # Stanza 지원 언어인지 확인
+        stanza_lang = LANGDETECT_TO_STANZA.get(lang, lang)
+        if stanza_lang in STANZA_SUPPORTED or lang in STANZA_SUPPORTED:
+            return _stanza_nouns(text, lang)
+        else:
+            # 최후의 fallback
+            return _fallback_tokenizer(text)
+
+# ============================================================
+# 6) 부분문자열(중복) 제거
+# ============================================================
 def _dedup_substrings(candidates: List[str], top_n: int) -> List[str]:
-    """
-    - 상위 후보들에서 다른 항목의 부분문자열인 경우 제거
-    - 예: '너무', '너무 길고' → '너무'만 남김(짧은 핵심어 우선)
-    """
-    filtered = []
-    for kw in candidates:
-        # kw가 더 긴 문구의 부분이면(= 긴 문구 존재) 짧은 쪽만 남기려면
-        # '긴 문구 제거'가 아니라 '짧은 걸 남기기'니까
-        # 긴 문구가 존재해도 kw를 남기고, 긴 문구는 뒤에서 자연히 걸러짐.
-        # → 반대로 구현: kw가 '다른 항목의 부분문자열'이면 긴 항목을 버리도록
-        if any((longer != kw and longer.find(kw) != -1) for longer in candidates):
-            # 긴 항목을 제거하는 로직을 적용하기 위해,
-            # 여기서는 일단 kw를 보류하고 긴 항목들이 필터링되도록 구조를 단순화.
-            pass
-        filtered.append(kw)
-
-    # 이제 긴 항목(= 다른 키워드를 포함하는 항목)을 제거
-    final = []
-    for kw in filtered:
-        if not any((short != kw and kw.find(short) != -1) for short in filtered):
-            final.append(kw)
-
-    # 고유 순서 유지 후 상위 N개 반환
+    """다른 키워드를 포함하는 긴 항목 제거"""
+    final = [
+        kw for kw in candidates
+        if not any(short != kw and kw.find(short) != -1 for short in candidates)
+    ]
+    
+    # 중복 제거 후 상위 N개 반환
     seen = set()
-    uniq = []
-    for w in final:
-        if w not in seen:
-            uniq.append(w); seen.add(w)
-    return uniq[:top_n]
+    return [w for w in final if not (w in seen or seen.add(w))][:top_n]
 
-# -----------------------------
-# 4) 메인 함수
-# -----------------------------
+# ============================================================
+# 7) 메인 함수
+# ============================================================
 def extract_keywords_tfidf(comments: List[str], top_n: int = 10) -> List[str]:
     """
-    TF-IDF 상위 키워드 추출
+    TF-IDF 상위 키워드 추출 (다국어 지원)
     - comments: 문서 리스트
     - top_n: 상위 몇 개 단어를 반환할지
-    - 불용어 제거 + 1~2그램 + 부분중복 제거
+    - 다국어 명사 추출 + 불용어 제거 + 1~2그램 + 부분중복 제거
+    
+    지원 언어:
+    - 최적화: 한국어, 영어, 일본어, 중국어
+    - Stanza: 독일어, 프랑스어, 스페인어, 러시아어 등 70개+
+    - Fallback: 기타 모든 언어
     
     반환:
         List[str]: 추출된 키워드 리스트 (AIAnalysisResponse의 keywords 필드)
@@ -146,11 +426,12 @@ def extract_keywords_tfidf(comments: List[str], top_n: int = 10) -> List[str]:
         return []
 
     vec = TfidfVectorizer(
-        tokenizer=_simple_tokenizer,   # 커스텀 토크나이저
+        tokenizer=_multilingual_noun_tokenizer,
         analyzer="word",
-        lowercase=False,               # we handle case in tokenizer
-        ngram_range=(1, 2),            # 1~2 gram
+        lowercase=False,
+        ngram_range=(1, 2),
         max_features=5000,
+        token_pattern=None,
     )
     X = vec.fit_transform(comments)
 
@@ -160,15 +441,16 @@ def extract_keywords_tfidf(comments: List[str], top_n: int = 10) -> List[str]:
 
     # 넉넉히 뽑은 다음(중복 제거 전) 정제
     raw_top = [w for w, _ in pairs[: top_n * 5]]
-    # 불용어가 포함된 빅그램 정리(두 토큰이 전부 불용어면 버림)
+    
+    # 불용어가 포함된 빅그램 정리
     cleaned = []
     for w in raw_top:
         parts = w.split()
-        if len(parts) == 2 and all(p in COMMON_STOPWORDS or len(p) < 2 for p in parts):
+        if len(parts) == 2 and all(p in ALL_STOPWORDS or len(p) < 2 for p in parts):
             continue
         cleaned.append(w)
 
-    # 부분문자열 중복 제거(짧은 핵심어 위주로 남김)
+    # 부분문자열 중복 제거
     return _dedup_substrings(cleaned, top_n)
 
 
@@ -178,26 +460,39 @@ def extract_keywords_tfidf(comments: List[str], top_n: int = 10) -> List[str]:
 if __name__ == "__main__":
     import json
     
-    # config.py에서 VIDEO_KEY 확인
     if not VIDEO_KEY:
         print("[ERROR] VIDEO_KEY가 .env 파일에 설정되지 않았습니다.")
         print("[INFO] 테스트 데이터로 실행합니다.\n")
         
-        # 테스트 데이터
+        # 테스트 데이터 (다국어)
         test_comments = [
+            # 한국어
             "정말 유익한 영상이네요! 감사합니다.",
-            "설명이 정말 잘 되어있어요. 유익한 정보 감사합니다.",
-            "이해하기 쉽게 설명해주셔서 감사해요.",
-            "좋은 정보 감사합니다. 도움이 많이 되었어요.",
-            "유익한 영상 감사합니다. 구독하고 갑니다!",
+            "언니가 돌아왔어요! 찰스 최고!",
+            # 영어
+            "This video is amazing! Great content!",
+            "Love the editing style and music choice.",
+            # 일본어
+            "この動画は本当に面白いです！",
+            "編集がとても上手ですね。",
+            # 중국어
+            "这个视频太棒了！内容很有趣。",
+            "剪辑做得很好，音乐也很配。",
+            # 독일어 (Stanza)
+            "Dieses Video ist fantastisch! Tolle Arbeit!",
+            # 프랑스어 (Stanza)
+            "Cette vidéo est incroyable! J'adore le contenu.",
+            # 스페인어 (Stanza)
+            "Este video es increíble! Me encanta.",
+            # 러시아어 (Stanza)
+            "Это видео потрясающее! Отличная работа!",
         ]
         
-        keywords = extract_keywords_tfidf(test_comments, top_n=10)
+        keywords = extract_keywords_tfidf(test_comments, top_n=15)
         
-        # JSON 형식으로 출력
         result = {"keywords": keywords}
         print("=" * 60)
-        print("[결과] 키워드 추출 (테스트 데이터):")
+        print("[결과] 키워드 추출 (다국어 테스트 데이터):")
         print("=" * 60)
         print(json.dumps(result, indent=2, ensure_ascii=False))
         print("=" * 60)
@@ -210,14 +505,13 @@ if __name__ == "__main__":
         print(f"[INFO] YouTube 비디오 '{VIDEO_KEY}'에서 댓글 수집 중...")
         
         try:
-            # YouTube 댓글 수집
             youtube_comments = fetch_youtube_comments(
                 video_id=VIDEO_KEY,
                 api_key=YOUTUBE_API_KEY,
-                max_pages=1,           # 1페이지 (100개)
-                page_size=100,         # 페이지당 100개
-                include_replies=False, # 대댓글 제외
-                apply_cleaning=True,   # 텍스트 전처리 적용
+                max_pages=1,
+                page_size=100,
+                include_replies=False,
+                apply_cleaning=True,
             )
             
             print(f"[SUCCESS] {len(youtube_comments)}개 댓글 수집 완료!")
@@ -226,13 +520,9 @@ if __name__ == "__main__":
                 print("[WARNING] 수집된 댓글이 없습니다.")
                 sys.exit(0)
             
-            # 키워드 추출 실행
             print(f"[INFO] 키워드 추출 중...\n")
             keywords = extract_keywords_tfidf(youtube_comments, top_n=10)
             
-            # ============================================================
-            # JSON 형식으로 결과 출력 (AIAnalysisResponse의 keywords 필드)
-            # ============================================================
             result = {"keywords": keywords}
             
             print("=" * 60)


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #25 

---

### 📌 요약
- 키워드 추출 기능을 다국어 지원 + 명사만 추출하도록 개선

### ✅ 작업 내용
- 토크나이저 변경: 정규식 기반 → 형태소 분석기 기반
  - 한국어: kiwipiepy (NNG, NNP 태그)
  - 영어: spaCy (NOUN, PROPN)
  - 일본어: fugashi (名詞)
  - 중국어: jieba (n* 태그)
  - 기타 70개+ 언어: Stanza
- 불용어 확장
  - 독일어, 프랑스어, 스페인어, 러시아어 불용어 추가
  - 범용 인터넷 표현 불용어 추가 (xd, lol, nice 등)
- langdetect로 언어 감지 후 적절한 토크나이저로 분기

### 💭 리뷰 포인트
- 짧은 댓글에서 langdetect 오탐 가능성 있음 (da, fi 등으로 잘못 감지)
- Stanza 모델은 최초 사용 시 자동 다운로드됨

### 📚 참고 자료, 할 말
- 새로운 의존성: kiwipiepy, spacy, fugashi, unidic-lite, jieba, stanza
- spaCy 영어 모델 별도 설치 필요: `python -m spacy download en_core_web_sm`